### PR TITLE
Fix consumers not reconnecting 

### DIFF
--- a/_examples/consumer/main.go
+++ b/_examples/consumer/main.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"log"
+	"sync"
+	"time"
+
+	"github.com/rafaeljesus/rabbus"
+)
+
+var (
+	RABBUS_DSN = "amqp://localhost:5672"
+	timeout    = time.After(time.Second * 3)
+	wg         sync.WaitGroup
+)
+
+func main() {
+	config := rabbus.Config{
+		Dsn:     RABBUS_DSN,
+		Durable: true,
+		Retry: rabbus.Retry{
+			Attempts: 5,
+		},
+		Breaker: rabbus.Breaker{
+			Threshold: 3,
+			OnStateChange: func(name, from, to string) {
+				// do something when state is changed
+			},
+		},
+	}
+
+	r, err := rabbus.NewRabbus(config)
+	if err != nil {
+		log.Fatalf("Failed to init rabbus connection %s", err)
+		return
+	}
+
+	defer func(r rabbus.Rabbus) {
+		if err := r.Close(); err != nil {
+			log.Fatalf("Failed to close rabbus connection %s", err)
+		}
+	}(r)
+
+	messages, err := r.Listen(rabbus.ListenConfig{
+		Exchange: "consumer_test_ex",
+		Kind:     "direct",
+		Key:      "consumer_test_key",
+		Queue:    "consumer_test_q",
+	})
+	if err != nil {
+		log.Fatalf("Failed to create listener %s", err)
+		return
+	}
+	defer close(messages)
+
+	for {
+		log.Println("Listening for messages...")
+
+		m, ok := <-messages
+		if !ok {
+			log.Println("Stop listening messages!")
+			break
+		}
+
+		m.Ack(false)
+
+		log.Println("Message was consumed")
+	}
+}

--- a/_examples/producer/main.go
+++ b/_examples/producer/main.go
@@ -11,7 +11,6 @@ import (
 var (
 	RABBUS_DSN = "amqp://localhost:5672"
 	timeout    = time.After(time.Second * 3)
-	wg         sync.WaitGroup
 )
 
 func main() {
@@ -56,12 +55,8 @@ outer:
 		select {
 		case <-r.EmitOk():
 			log.Println("Message was sent")
-			wg.Wait()
-			log.Println("Done!")
-			break outer
 		case err := <-r.EmitErr():
 			log.Fatalf("Failed to send message %s", err)
-			break outer
 		case <-timeout:
 			log.Fatal("Timeout error during send message")
 			break outer

--- a/_examples/producer/main.go
+++ b/_examples/producer/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"log"
-	"sync"
 	"time"
 
 	"github.com/rafaeljesus/rabbus"
@@ -57,8 +56,9 @@ outer:
 			log.Println("Message was sent")
 		case err := <-r.EmitErr():
 			log.Fatalf("Failed to send message %s", err)
+			break outer
 		case <-timeout:
-			log.Fatal("Timeout error during send message")
+			log.Println("Bye")
 			break outer
 		}
 	}

--- a/_examples/producer/main.go
+++ b/_examples/producer/main.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"log"
+	"sync"
+	"time"
+
+	"github.com/rafaeljesus/rabbus"
+)
+
+var (
+	RABBUS_DSN = "amqp://localhost:5672"
+	timeout    = time.After(time.Second * 3)
+	wg         sync.WaitGroup
+)
+
+func main() {
+	config := rabbus.Config{
+		Dsn:     RABBUS_DSN,
+		Durable: true,
+		Retry: rabbus.Retry{
+			Attempts: 5,
+		},
+		Breaker: rabbus.Breaker{
+			Threshold: 3,
+			OnStateChange: func(name, from, to string) {
+				// do something when state is changed
+			},
+		},
+	}
+
+	r, err := rabbus.NewRabbus(config)
+	if err != nil {
+		log.Fatalf("Failed to init rabbus connection %s", err)
+		return
+	}
+
+	defer func(r rabbus.Rabbus) {
+		if err := r.Close(); err != nil {
+			log.Fatalf("Failed to close rabbus connection %s", err)
+		}
+	}(r)
+
+	msg := rabbus.Message{
+		Exchange:     "producer_test_ex",
+		Kind:         "direct",
+		Key:          "producer_test_key",
+		Payload:      []byte(`foo`),
+		DeliveryMode: rabbus.Persistent,
+	}
+
+	r.EmitAsync() <- msg
+
+outer:
+	for {
+		select {
+		case <-r.EmitOk():
+			log.Println("Message was sent")
+			wg.Wait()
+			log.Println("Done!")
+			break outer
+		case err := <-r.EmitErr():
+			log.Fatalf("Failed to send message %s", err)
+			break outer
+		case <-timeout:
+			log.Fatal("Timeout error during send message")
+			break outer
+		}
+	}
+}

--- a/_examples/pubsub/main.go
+++ b/_examples/pubsub/main.go
@@ -43,10 +43,10 @@ func main() {
 	}(r)
 
 	messages, err := r.Listen(rabbus.ListenConfig{
-		Exchange: "test_ex",
+		Exchange: "pubsub_test_ex",
 		Kind:     "direct",
-		Key:      "test_key",
-		Queue:    "test_q",
+		Key:      "pubsub_test_key",
+		Queue:    "pubsub_test_q",
 	})
 	if err != nil {
 		log.Fatalf("Failed to create listener %s", err)
@@ -64,9 +64,9 @@ func main() {
 	}(messages)
 
 	msg := rabbus.Message{
-		Exchange:     "test_ex",
+		Exchange:     "pubsub_test_ex",
 		Kind:         "direct",
-		Key:          "test_key",
+		Key:          "pubsub_test_key",
 		Payload:      []byte(`foo`),
 		DeliveryMode: rabbus.Persistent,
 	}

--- a/consumer_message.go
+++ b/consumer_message.go
@@ -70,7 +70,7 @@ func newConsumerMessage(m amqp.Delivery) ConsumerMessage {
 // When multiple is true, this delivery and all prior unacknowledged deliveries on the same channel will be acknowledged. This is useful for batch processing of deliveries.
 // An error will indicate that the acknowledge could not be delivered to the channel it was sent from.
 // Either Delivery.Ack, Delivery.Reject or Delivery.Nack must be called for every delivery that is not automatically acknowledged.
-func (cm *ConsumerMessage) Ack(multiple bool) error {
+func (cm ConsumerMessage) Ack(multiple bool) error {
 	return cm.delivery.Ack(multiple)
 }
 
@@ -79,7 +79,7 @@ func (cm *ConsumerMessage) Ack(multiple bool) error {
 // When requeue is true, request the server to deliver this message to a different consumer. If it is not possible or requeue is false, the message will be dropped or delivered to a server configured dead-letter queue.
 // This method must not be used to select or requeue messages the client wishes not to handle, rather it is to inform the server that the client is incapable of handling this message at this time.
 // Either Delivery.Ack, Delivery.Reject or Delivery.Nack must be called for every delivery that is not automatically acknowledged.
-func (cm *ConsumerMessage) Nack(multiple, requeue bool) error {
+func (cm ConsumerMessage) Nack(multiple, requeue bool) error {
 	return cm.delivery.Nack(multiple, requeue)
 }
 
@@ -87,6 +87,6 @@ func (cm *ConsumerMessage) Nack(multiple, requeue bool) error {
 // When requeue is true, queue this message to be delivered to a consumer on a different channel. When requeue is false or the server is unable to queue this message, it will be dropped.
 // If you are batch processing deliveries, and your server supports it, prefer Delivery.Nack.
 // Either Delivery.Ack, Delivery.Reject or Delivery.Nack must be called for every delivery that is not automatically acknowledged.
-func (cm *ConsumerMessage) Reject(requeue bool) error {
+func (cm ConsumerMessage) Reject(requeue bool) error {
 	return cm.delivery.Reject(requeue)
 }

--- a/rabbus_test.go
+++ b/rabbus_test.go
@@ -5,8 +5,6 @@ import (
 	"sync"
 	"testing"
 	"time"
-
-	"github.com/streadway/amqp"
 )
 
 const (
@@ -27,10 +25,6 @@ func TestRabbus(t *testing.T) {
 		{
 			scenario: "rabbus listen",
 			function: testRabbusListen,
-		},
-		{
-			scenario: "rabbus with managed connection listen",
-			function: testRabbusWithManagedConnListen,
 		},
 		{
 			scenario: "rabbus listen validate",
@@ -69,79 +63,6 @@ func BenchmarkRabbus(b *testing.B) {
 
 func testRabbusListen(t *testing.T) {
 	r, err := NewRabbus(Config{
-		Dsn:     RABBUS_DSN,
-		Durable: true,
-		Retry: Retry{
-			Attempts: 1,
-		},
-		Breaker: Breaker{
-			Timeout: time.Second * 2,
-		},
-	})
-	if err != nil {
-		t.Errorf("Expected to init rabbus %s", err)
-	}
-
-	defer func(r Rabbus) {
-		if err = r.Close(); err != nil {
-			t.Errorf("Expected to close rabbus %s", err)
-		}
-	}(r)
-
-	messages, err := r.Listen(ListenConfig{
-		Exchange: "test_ex",
-		Kind:     "direct",
-		Key:      "test_key",
-		Queue:    "test_q",
-	})
-	if err != nil {
-		t.Errorf("Expected to listen message %s", err)
-	}
-
-	var wg sync.WaitGroup
-	wg.Add(1)
-
-	go func(messages chan ConsumerMessage) {
-		for m := range messages {
-			m.Ack(false)
-			close(messages)
-			wg.Done()
-		}
-	}(messages)
-
-	msg := Message{
-		Exchange:     "test_ex",
-		Kind:         "direct",
-		Key:          "test_key",
-		Payload:      []byte(`foo`),
-		DeliveryMode: Persistent,
-	}
-
-	r.EmitAsync() <- msg
-
-outer:
-	for {
-		select {
-		case <-r.EmitOk():
-			wg.Wait()
-			break outer
-		case <-r.EmitErr():
-			t.Errorf("Expected to emit message")
-			break outer
-		case <-timeout:
-			t.Errorf("parallel.Run() failed, got timeout error")
-			break outer
-		}
-	}
-}
-
-func testRabbusWithManagedConnListen(t *testing.T) {
-	conn, err := amqp.Dial(RABBUS_DSN)
-	if err != nil {
-		t.Errorf("Expected to create amqp.Connection %s", err)
-	}
-
-	r, err := NewRabbusWithManagedConn(conn, Config{
 		Dsn:     RABBUS_DSN,
 		Durable: true,
 		Retry: Retry{


### PR DESCRIPTION
This PR fixes a issue we had during broker restarts. Basically the consumers weren't receiving messages if amqp either amqp connection or channel dies, only after manually restarting the consumers again.

- [x] Fix consumers reconnection
- [x] Deprecate the `NewRabbusWithManagedConn` since rabbus should manage that for the user.
- [x] Improve examples