### PR TITLE
Get rid of hidden goroutines

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 ## Rabbus 🚌 ✨
 
 * A tiny wrapper over [amqp](https://github.com/streadway/amqp) exchanges and queues.
-* Automatic retries and exponential backoff for sending messages.
-* Makes use of [gobreaker](https://github.com/sony/gobreaker).
-* Automatic reconnect to RabbitMQ broker.
-* Golang channel API.
+* In memory retries with exponential backoff for sending messages.
+* Protect producer calls with [circuit breaker](https://github.com/sony/gobreaker).
+* Automatic reconnect to RabbitMQ broker when connection is lost.
+* Go channel API.
 
 ## Installation
 ```bash
@@ -17,6 +17,7 @@ The rabbus package exposes an interface for emitting and listening RabbitMQ mess
 ### Emit
 ```go
 import (
+	"context"
 	"time"
 
 	"github.com/rafaeljesus/rabbus"
@@ -45,6 +46,11 @@ func main() {
 		}
 	}(r)
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go r.Run(ctx)
+
 	msg := rabbus.Message{
 		Exchange: "test_ex",
 		Kind:     "topic",
@@ -70,6 +76,7 @@ func main() {
 ### Listen
 ```go
 import (
+	"context"
 	"encoding/json"
 	"time"
 
@@ -98,6 +105,11 @@ func main() {
 			// handle error
 		}
 	}(r)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go r.Run(ctx)
 
 	messages, err := r.Listen(rabbus.ListenConfig{
 		Exchange: "events_ex",

--- a/_examples/producer/main.go
+++ b/_examples/producer/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"log"
 	"time"
 
@@ -34,6 +35,11 @@ func main() {
 			log.Fatalf("Failed to close rabbus connection %s", err)
 		}
 	}(r)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go r.Run(ctx)
 
 	msg := rabbus.Message{
 		Exchange:     "producer_test_ex",

--- a/_examples/pubsub/main.go
+++ b/_examples/pubsub/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"log"
 	"sync"
 	"time"
@@ -36,6 +37,11 @@ func main() {
 			log.Fatalf("Failed to close rabbus connection %s", err)
 		}
 	}(r)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go r.Run(ctx)
 
 	messages, err := r.Listen(rabbus.ListenConfig{
 		Exchange: "pubsub_test_ex",

--- a/integration/rabbus_integration_test.go
+++ b/integration/rabbus_integration_test.go
@@ -1,6 +1,7 @@
 package rabbus
 
 import (
+	"context"
 	"strconv"
 	"sync"
 	"testing"
@@ -72,6 +73,11 @@ func testRabbusPublishSubscribe(t *testing.T) {
 		}
 	}(r)
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go r.Run(ctx)
+
 	messages, err := r.Listen(rabbus.ListenConfig{
 		Exchange: "test_ex",
 		Kind:     "direct",
@@ -134,6 +140,11 @@ func benchmarkEmitAsync(b *testing.B) {
 			b.Fatalf("expected to close rabbus %s", err)
 		}
 	}(r)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go r.Run(ctx)
 
 	var wg sync.WaitGroup
 	wg.Add(b.N)

--- a/internal/amqp/amqp.go
+++ b/internal/amqp/amqp.go
@@ -1,8 +1,6 @@
 package amqp
 
-import (
-	"github.com/streadway/amqp"
-)
+import "github.com/streadway/amqp"
 
 // Amqp interpret (implement) Amqp interface definition
 type Amqp struct {

--- a/rabbus_test.go
+++ b/rabbus_test.go
@@ -48,18 +48,18 @@ func TestRabbus(t *testing.T) {
 			"emit async message",
 			testEmitAsyncMessage,
 		},
-		//{
-		//"emit async message fail to declare exchange",
-		//testEmitAsyncMessageFailToDeclareExchange,
-		//},
-		//{
-		//"emit async message fail to publish",
-		//testEmitAsyncMessageFailToPublish,
-		//},
-		//{
-		//"emit async message ensure breaker",
-		//testEmitAsyncMessageEnsureBreaker,
-		//},
+		{
+			"emit async message fail to declare exchange",
+			testEmitAsyncMessageFailToDeclareExchange,
+		},
+		{
+			"emit async message fail to publish",
+			testEmitAsyncMessageFailToPublish,
+		},
+		{
+			"emit async message ensure breaker",
+			testEmitAsyncMessageEnsureBreaker,
+		},
 	}
 
 	for _, test := range tests {
@@ -310,13 +310,12 @@ func testEmitAsyncMessageFailToDeclareExchange(t *testing.T) {
 		}
 	}(r)
 
-	r.EmitAsync() <- msg
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	go r.Run(ctx)
 
+	r.EmitAsync() <- msg
 outer:
 	for {
 		select {


### PR DESCRIPTION
This PR expose `Run` method with support for contexts, with this new design rabbus does't spawn hidden goroutines anymore, giving full control for the user.

Before:
```go
r, _ := rabbus.New(dsn)
r.EmitAsync() <- rabbus.Message{}

for {
  select {
    case <-r.EmitOk():
    case err := <- r.EmitErr():
    case timeout:
  }
}
```

Now:
```go
r, _ := rabbus.New(dsn)
ctx, cancel := context.WithCancel(context.Background())
defer cancel()

go r.Run(ctx)

r.EmitAsync() <- rabbus.Message{}

for {
  select {
    case <-r.EmitOk():
    case err := <- r.EmitErr():
    case timeout:
  }
}
```