### PR TITLE
fix for consumer bindings are lost after a restart

### DIFF
--- a/rabbus.go
+++ b/rabbus.go
@@ -222,8 +222,8 @@ func (r *Rabbus) Listen(c ListenConfig) (chan ConsumerMessage, error) {
 		return nil, err
 	}
 
-	r.conDeclared++ // increase the declared consumer's counter
 	r.mu.Lock()
+	r.conDeclared++ // increase the declared consumers counter
 	r.exDeclared[c.Exchange] = struct{}{}
 	r.mu.Unlock()
 

--- a/rabbus.go
+++ b/rabbus.go
@@ -81,6 +81,7 @@ type (
 		reconn     chan struct{}
 		exDeclared map[string]struct{}
 		config
+		conDeclared int // conDeclared is a counter for the declared consumers
 	}
 
 	// Amqp expose a interface for interacting with amqp broker
@@ -221,6 +222,7 @@ func (r *Rabbus) Listen(c ListenConfig) (chan ConsumerMessage, error) {
 		return nil, err
 	}
 
+	r.conDeclared++ // increase the declared consumer's counter
 	r.mu.Lock()
 	r.exDeclared[c.Exchange] = struct{}{}
 	r.mu.Unlock()
@@ -412,7 +414,9 @@ func (r *Rabbus) handleAmqpClose(err error) {
 		r.mu.Lock()
 		r.Amqp = aw
 		r.mu.Unlock()
-		r.reconn <- struct{}{}
+		for i := 1; i <= r.conDeclared; i++ {
+			r.reconn <- struct{}{}
+		}
 		break
 	}
 }

--- a/rabbus_test.go
+++ b/rabbus_test.go
@@ -76,10 +76,10 @@ func testCreateNewSpecifyingAmqpProvider(t *testing.T) {
 	provider := new(amqpMock)
 	provider.withQosFn = func(c, s int, g bool) error {
 		if count != c {
-			t.Fatalf("unexpected prefetch count: %t", c)
+			t.Fatalf("unexpected prefetch count: %d", c)
 		}
 		if size != s {
-			t.Fatalf("unexpected prefetch size: %t", s)
+			t.Fatalf("unexpected prefetch size: %d", s)
 		}
 		if global != g {
 			t.Fatalf("unexpected global: %t", g)


### PR DESCRIPTION
> when Rabbitmq connection is lost either by cluster restart or killing the connection, our Go consumers re-create it, however, **the queue bindings are lost** which means that no consumer gets attached in the queue and thus no message will get processed until the binary is restarted.