### PR TITLE
There is some issue on publishing when there is a rabbitmq disconnection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,8 @@ integration-test:
 	@docker-compose up -d
 	@sleep 3
 	AMQP_DSN="amqp://guest:guest@`docker-compose port rabbit 5672`/" \
-		go test -v -cover integration/rabbus_integration_test.go -bench .
+	AMQP_MANAGEMENT_PORT="http://`docker-compose port rabbit 15672`/api" \
+		go test -timeout=30s -v -cover integration/rabbus_integration_test.go -bench .
 	@docker-compose down -v
 
 integration-test-ci:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,3 +4,4 @@ services:
     image: rabbitmq:3.6-management-alpine
     ports:
       - "5672"
+      - "15672"

--- a/integration/rabbus_integration_test.go
+++ b/integration/rabbus_integration_test.go
@@ -2,6 +2,10 @@ package rabbus
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
 	"os"
 	"strconv"
 	"sync"
@@ -12,7 +16,8 @@ import (
 )
 
 const (
-	amqpDsnEnv = "AMQP_DSN"
+	amqpDsnEnv        = "AMQP_DSN"
+	amqpManagementEnv = "AMQP_MANAGEMENT_PORT"
 )
 
 var (
@@ -26,8 +31,6 @@ func TestRabbus(t *testing.T) {
 	}
 
 	amqpDsn = os.Getenv(amqpDsnEnv)
-
-	t.Parallel()
 
 	tests := []struct {
 		scenario string
@@ -189,4 +192,150 @@ func benchmarkEmitAsync(b *testing.B) {
 	}
 
 	wg.Wait()
+}
+
+func TestPublishDisconnect(t *testing.T) {
+	if os.Getenv(amqpDsnEnv) == "" || os.Getenv(amqpManagementEnv) == "" {
+		t.SkipNow()
+	}
+
+	amqpDsn = os.Getenv(amqpDsnEnv)
+	amqpManagement := os.Getenv(amqpManagementEnv)
+
+	r, err := rabbus.New(
+		amqpDsn,
+		rabbus.Durable(true),
+		rabbus.Attempts(2),
+		rabbus.BreakerTimeout(time.Millisecond*2),
+	)
+	if err != nil {
+		t.Fatalf("expected to init rabbus %s", err)
+	}
+
+	defer func(r *rabbus.Rabbus) {
+		if err = r.Close(); err != nil {
+			t.Errorf("expected to close rabbus %s", err)
+		}
+	}(r)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go r.Run(ctx)
+
+	msg := rabbus.Message{
+		Exchange:     "test_ex_kill",
+		Kind:         rabbus.ExchangeDirect,
+		Key:          "test_key",
+		Payload:      []byte(`foo`),
+		DeliveryMode: rabbus.Persistent,
+	}
+
+	r.EmitAsync() <- msg
+	select {
+	case <-r.EmitOk():
+
+	case <-r.EmitErr():
+		t.Error("expected to emit message")
+	case <-timeout:
+		t.Error("parallel.Run() failed, got timeout error")
+	}
+	killConnections(t, amqpManagement)
+
+	r.EmitAsync() <- msg
+	select {
+	case <-r.EmitOk():
+
+	case <-r.EmitErr():
+		t.Error("expected to emit message")
+	case <-time.After(5 * time.Second):
+		t.Error("parallel.Run() failed, got timeout error")
+	}
+
+}
+
+type amqpConnection struct {
+	Name string `json:"name"`
+}
+
+// return all connections opened in rabbitmq via the management API
+func getConnections(amqpManagement string) ([]amqpConnection, error) {
+	client := &http.Client{}
+	url := fmt.Sprintf("%s/connections", amqpManagement)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.SetBasicAuth("guest", "guest")
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Non 200 response: %s", resp.Status)
+	}
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	r := make([]amqpConnection, 0)
+	err = json.Unmarshal(b, &r)
+	if err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+// close one connection
+func killConnection(connection amqpConnection, amqpManagement string) error {
+	client := &http.Client{}
+	url := fmt.Sprintf("%s/connections/%s", amqpManagement, connection.Name)
+
+	req, err := http.NewRequest("DELETE", url, nil)
+	if err != nil {
+		return err
+	}
+	req.SetBasicAuth("guest", "guest")
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("deletion of connection failed, status: %s", resp.Status)
+	}
+	return nil
+}
+
+// close all open connections to the rabbitmq via the management api
+func killConnections(t *testing.T, amqpManagement string) {
+	conns := make(chan []amqpConnection)
+	go func() {
+		for {
+			connections, err := getConnections(amqpManagement)
+			if err != nil {
+				t.Error(err)
+			}
+			if len(connections) >= 1 {
+				conns <- connections
+				break //exit the loop
+			}
+			//the rabbitmq api is a bit slow to update, we have to wait a bit
+			time.Sleep(time.Second)
+		}
+	}()
+	select {
+	case connections := <-conns:
+		for _, c := range connections {
+			t.Log(c.Name)
+			if err := killConnection(c, amqpManagement); err != nil {
+				t.Errorf("impossible to kill connection (%s): %s", c.Name, err)
+			}
+		}
+	case <-time.After(time.Second * 10):
+		t.Error("timeout for killing connection reached")
+	}
 }


### PR DESCRIPTION
In case of a deconnection we encounter a "deadlock" that prevent rabbus from reconnecting.

Calling NotifyClose in the amqp package will try to acquire a lock: https://github.com/streadway/amqp/blob/master/connection.go#L267-L278
This is what happen in the first goroutine (#41) of my log.

In case of an error an internal goroutine of amqp will try to notify every receiver that en error has been encountered by sending the error to the channels previously registered: https://github.com/streadway/amqp/blob/master/connection.go#L387-L389
This is done after acquiring the lock of the connection. This is the second goroutine (#14).

So the second goroutine as lock the mutex and is blocked waiting someone to read the channel, while the firstgoroutine, the one that should read the channel, is blocked by the mutex while trying to add a new channel to notify.


Here a trace that  exhibit this behavior:

```
goroutine 41 [semacquire, 29 minutes]:
sync.runtime_SemacquireMutex(0xc420212158, 0xd78600)
	/usr/local/go/src/runtime/sema.go:71 +0x3d
sync.(*Mutex).Lock(0xc420212154)
	/usr/local/go/src/sync/mutex.go:134 +0x108
github.com/rafaeljesus/rabbus/vendor/github.com/streadway/amqp.(*Connection).NotifyClose(0xc420212140, 0xc420379bc0, 0x0)
	/home/kinou/go/src/github.com/rafaeljesus/rabbus/vendor/github.com/streadway/amqp/connection.go:268 +0x43
github.com/rafaeljesus/rabbus/internal/amqp.(*Amqp).NotifyClose(0xc42017ae60, 0xc420379bc0, 0xc420379bc0)
	/home/kinou/go/src/github.com/rafaeljesus/rabbus/internal/amqp/amqp.go:68 +0x38
github.com/rafaeljesus/rabbus.(*Rabbus).Run(0xc42030c410, 0xe28da0, 0xc42018c640, 0x1, 0x0)
	/home/kinou/go/src/github.com/rafaeljesus/rabbus/rabbus.go:201 +0xb0
main.main.func3(0xc42030c410, 0xe28da0, 0xc42018c640, 0xc42017c620)
	/home/kinou/go/src/github.com/CanalTP/gormungandr/cmd/schedules/main.go:169 +0x43
created by main.main
	/home/kinou/go/src/github.com/CanalTP/gormungandr/cmd/schedules/main.go:168 +0xcc2

goroutine 14 [chan send, 30 minutes]:
github.com/rafaeljesus/rabbus/vendor/github.com/streadway/amqp.(*Connection).shutdown.func1()
	/home/kinou/go/src/github.com/rafaeljesus/rabbus/vendor/github.com/streadway/amqp/connection.go:388 +0xc9
sync.(*Once).Do(0xc420212140, 0xc4203cadc8)
	/usr/local/go/src/sync/once.go:44 +0xbe
github.com/rafaeljesus/rabbus/vendor/github.com/streadway/amqp.(*Connection).shutdown(0xc420212140, 0xc4202dfdc0)
	/home/kinou/go/src/github.com/rafaeljesus/rabbus/vendor/github.com/streadway/amqp/connection.go:382 +0x5b
github.com/rafaeljesus/rabbus/vendor/github.com/streadway/amqp.(*Connection).dispatch0(0xc420212140, 0xe230a0, 0xc4202dfd40)
	/home/kinou/go/src/github.com/rafaeljesus/rabbus/vendor/github.com/streadway/amqp/connection.go:444 +0x364
github.com/rafaeljesus/rabbus/vendor/github.com/streadway/amqp.(*Connection).demux(0xc420212140, 0xe230a0, 0xc4202dfd40)
	/home/kinou/go/src/github.com/rafaeljesus/rabbus/vendor/github.com/streadway/amqp/connection.go:427 +0x5d
github.com/rafaeljesus/rabbus/vendor/github.com/streadway/amqp.(*Connection).reader(0xc420212140, 0x7f05890710d0, 0xc42000e798)
	/home/kinou/go/src/github.com/rafaeljesus/rabbus/vendor/github.com/streadway/amqp/connection.go:521 +0xe6
created by github.com/rafaeljesus/rabbus/vendor/github.com/streadway/amqp.Open
	/home/kinou/go/src/github.com/rafaeljesus/rabbus/vendor/github.com/streadway/amqp/connection.go:228 +0x287

```

This is caused by this code in ```Rabbus::Run```:
```
    Select {
        ...
		case err, ok := <-r.NotifyClose(make(chan *amqp.Error)):
			if ok {
				r.handleAmqpClose(err)
			}
        ...
    }

```

NotifyClose shouldn't be call on every iteration of the loop, but only one time for each connection
as it register a receiver that will be valid until it closed.
I think that for each message published/emited we add a new receiver with NotifyClose, and only the last one will be be listen to, so even without the Mutex we will still be stuck.

With This PR we only call `NotifyClose` one time per connections, this has solved the problem in my manual testing.