### PR TITLE
add test for notify disconnect

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,8 @@ integration-test:
 	@docker-compose up -d
 	@sleep 3
 	AMQP_DSN="amqp://guest:guest@`docker-compose port rabbit 5672`/" \
-		go test -v -cover integration/rabbus_integration_test.go -bench .
+	AMQP_MANAGEMENT_PORT="http://`docker-compose port rabbit 15672`/api" \
+		go test -timeout=30s -v -cover integration/rabbus_integration_test.go -bench .
 	@docker-compose down -v
 
 integration-test-ci:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,3 +4,4 @@ services:
     image: rabbitmq:3.6-management-alpine
     ports:
       - "5672"
+      - "15672"

--- a/integration/rabbus_integration_test.go
+++ b/integration/rabbus_integration_test.go
@@ -2,6 +2,10 @@ package rabbus
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
 	"os"
 	"strconv"
 	"sync"
@@ -12,7 +16,8 @@ import (
 )
 
 const (
-	amqpDsnEnv = "AMQP_DSN"
+	amqpDsnEnv        = "AMQP_DSN"
+	amqpManagementEnv = "AMQP_MANAGEMENT_PORT"
 )
 
 var (
@@ -26,8 +31,6 @@ func TestRabbus(t *testing.T) {
 	}
 
 	amqpDsn = os.Getenv(amqpDsnEnv)
-
-	t.Parallel()
 
 	tests := []struct {
 		scenario string
@@ -189,4 +192,150 @@ func benchmarkEmitAsync(b *testing.B) {
 	}
 
 	wg.Wait()
+}
+
+func TestPublishDisconnect(t *testing.T) {
+	if os.Getenv(amqpDsnEnv) == "" || os.Getenv(amqpManagementEnv) == "" {
+		t.SkipNow()
+	}
+
+	amqpDsn = os.Getenv(amqpDsnEnv)
+	amqpManagement := os.Getenv(amqpManagementEnv)
+
+	r, err := rabbus.New(
+		amqpDsn,
+		rabbus.Durable(true),
+		rabbus.Attempts(2),
+		rabbus.BreakerTimeout(time.Millisecond*2),
+	)
+	if err != nil {
+		t.Fatalf("expected to init rabbus %s", err)
+	}
+
+	defer func(r *rabbus.Rabbus) {
+		if err = r.Close(); err != nil {
+			t.Errorf("expected to close rabbus %s", err)
+		}
+	}(r)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go r.Run(ctx)
+
+	msg := rabbus.Message{
+		Exchange:     "test_ex_kill",
+		Kind:         rabbus.ExchangeDirect,
+		Key:          "test_key",
+		Payload:      []byte(`foo`),
+		DeliveryMode: rabbus.Persistent,
+	}
+
+	r.EmitAsync() <- msg
+	select {
+	case <-r.EmitOk():
+
+	case <-r.EmitErr():
+		t.Error("expected to emit message")
+	case <-timeout:
+		t.Error("parallel.Run() failed, got timeout error")
+	}
+	killConnections(t, amqpManagement)
+
+	r.EmitAsync() <- msg
+	select {
+	case <-r.EmitOk():
+
+	case <-r.EmitErr():
+		t.Error("expected to emit message")
+	case <-time.After(5 * time.Second):
+		t.Error("parallel.Run() failed, got timeout error")
+	}
+
+}
+
+type amqpConnection struct {
+	Name string `json:"name"`
+}
+
+// return all connections opened in rabbitmq via the management API
+func getConnections(amqpManagement string) ([]amqpConnection, error) {
+	client := &http.Client{}
+	url := fmt.Sprintf("%s/connections", amqpManagement)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.SetBasicAuth("guest", "guest")
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Non 200 response: %s", resp.Status)
+	}
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	r := make([]amqpConnection, 0)
+	err = json.Unmarshal(b, &r)
+	if err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+// close one connection
+func killConnection(connection amqpConnection, amqpManagement string) error {
+	client := &http.Client{}
+	url := fmt.Sprintf("%s/connections/%s", amqpManagement, connection.Name)
+
+	req, err := http.NewRequest("DELETE", url, nil)
+	if err != nil {
+		return err
+	}
+	req.SetBasicAuth("guest", "guest")
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("deletion of connection failed, status: %s", resp.Status)
+	}
+	return nil
+}
+
+// close all open connections to the rabbitmq via the management api
+func killConnections(t *testing.T, amqpManagement string) {
+	conns := make(chan []amqpConnection)
+	go func() {
+		for {
+			connections, err := getConnections(amqpManagement)
+			if err != nil {
+				t.Error(err)
+			}
+			if len(connections) >= 1 {
+				conns <- connections
+				break //exit the loop
+			}
+			//the rabbitmq api is a bit slow to update, we have to wait a bit
+			time.Sleep(time.Second)
+		}
+	}()
+	select {
+	case connections := <-conns:
+		for _, c := range connections {
+			t.Log(c.Name)
+			if err := killConnection(c, amqpManagement); err != nil {
+				t.Errorf("impossible to kill connection (%s): %s", c.Name, err)
+			}
+		}
+	case <-time.After(time.Second * 10):
+		t.Error("timeout for killing connection reached")
+	}
 }


### PR DESCRIPTION
I had to remove the Parallel as is was messing with the
`rabbus_publish_subscribe` test.

I use the rabbitmq management API to close the connection. 
Without #34 this test will deadlock  