### PR TITLE
Fix close connection ordering issue

### DIFF
--- a/rabbus.go
+++ b/rabbus.go
@@ -256,12 +256,12 @@ func (r *Rabbus) Listen(c ListenConfig) (chan ConsumerMessage, error) {
 
 // Close channels and attempt to close channel and connection.
 func (r *Rabbus) Close() error {
+	err := r.Amqp.Close()
 	close(r.emit)
 	close(r.emitOk)
 	close(r.emitErr)
 	close(r.reconn)
-
-	return r.Amqp.Close()
+	return err
 }
 
 func (r *Rabbus) produce(m Message) {


### PR DESCRIPTION
closing `r.emit` before `notifyClose` would cause this error `Run` exit on a wrong case https://github.com/rafaeljesus/rabbus/blob/master/rabbus.go#L201

and you'll receive that error any time you execute rabbus.Close