### PR TITLE
Adds support for queue declare args

### DIFF
--- a/rabbus.go
+++ b/rabbus.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	amqpWrap "github.com/rafaeljesus/rabbus/internal/amqp"
+	
 	"github.com/rafaeljesus/retry-go"
 	"github.com/sony/gobreaker"
 	"github.com/streadway/amqp"
@@ -71,6 +72,11 @@ type (
 		PassiveExchange bool
 		// Queue the queue name
 		Queue string
+		// DeclareArgs is a list of arguments accepted for when declaring the queue.
+		// See https://www.rabbitmq.com/queues.html#optional-arguments for more info.
+		DeclareArgs amqp.Table
+		// BindArgs is a list of arguments accepted for when binding the exchange to the queue
+		BindArgs amqp.Table
 	}
 
 	// Delivery wraps amqp.Delivery struct
@@ -248,7 +254,7 @@ func (r *Rabbus) Listen(c ListenConfig) (chan ConsumerMessage, error) {
 		return nil, err
 	}
 
-	msgs, err := r.CreateConsumer(c.Exchange, c.Key, c.Kind, c.Queue, r.config.durable)
+	msgs, err := r.CreateConsumer(c.Exchange, c.Key, c.Kind, c.Queue, r.config.durable, c.DeclareArgs, c.BindArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -468,7 +474,7 @@ func (r *Rabbus) handleAmqpClose(err error) {
 
 func (r *Rabbus) listenReconn(c ListenConfig, messages chan ConsumerMessage) {
 	for range r.reconn {
-		msgs, err := r.CreateConsumer(c.Exchange, c.Key, c.Kind, c.Queue, r.config.durable)
+		msgs, err := r.CreateConsumer(c.Exchange, c.Key, c.Kind, c.Queue, r.config.durable, c.DeclareArgs, c.BindArgs)
 		if err != nil {
 			continue
 		}

--- a/rabbus_test.go
+++ b/rabbus_test.go
@@ -159,7 +159,7 @@ func testCreateNewListener(t *testing.T) {
 	}
 	provider := new(amqpMock)
 	provider.withQosFn = func(count, size int, global bool) error { return nil }
-	provider.createConsumerFn = func(exchange, key, kind, queue string, d bool) (<-chan amqp.Delivery, error) {
+	provider.createConsumerFn = func(exchange, key, kind, queue string, d bool, declareArgs, bindArgs amqp.Table) (<-chan amqp.Delivery, error) {
 		if exchange != config.Exchange {
 			t.Fatalf("unexpected exchange: %s", exchange)
 		}
@@ -200,7 +200,7 @@ func testCreateNewListener(t *testing.T) {
 func testFailToCreateNewListenerWhenCreateConsumerReturnsError(t *testing.T) {
 	provider := new(amqpMock)
 	provider.withQosFn = func(count, size int, global bool) error { return nil }
-	provider.createConsumerFn = func(exchange, key, kind, queue string, durable bool) (<-chan amqp.Delivery, error) {
+	provider.createConsumerFn = func(exchange, key, kind, queue string, durable bool, declareArgs, bindArgs amqp.Table) (<-chan amqp.Delivery, error) {
 		return nil, errAmqp
 	}
 	r, err := New(dsn, AmqpProvider(provider))
@@ -434,7 +434,7 @@ type amqpMock struct {
 	publishInvoked        bool
 	publishFn             func(exchange, key string, opts amqp.Publishing) error
 	createConsumerInvoked bool
-	createConsumerFn      func(exchange, key, kind, queue string, durable bool) (<-chan amqp.Delivery, error)
+	createConsumerFn      func(exchange, key, kind, queue string, durable bool, declareArgs, bindArgs amqp.Table) (<-chan amqp.Delivery, error)
 	withExchangeInvoked   bool
 	withExchangeFn        func(exchange, kind string, durable bool) error
 	withQosInvoked        bool
@@ -446,9 +446,9 @@ func (m *amqpMock) Publish(exchange, key string, opts amqp.Publishing) error {
 	return m.publishFn(exchange, key, opts)
 }
 
-func (m *amqpMock) CreateConsumer(exchange, key, kind, queue string, durable bool) (<-chan amqp.Delivery, error) {
+func (m *amqpMock) CreateConsumer(exchange, key, kind, queue string, durable bool, declareArgs, bindArgs amqp.Table) (<-chan amqp.Delivery, error) {
 	m.createConsumerInvoked = true
-	return m.createConsumerFn(exchange, key, kind, queue, durable)
+	return m.createConsumerFn(exchange, key, kind, queue, durable, declareArgs, bindArgs)
 }
 
 func (m *amqpMock) WithExchange(exchange, kind string, durable bool) error {


### PR DESCRIPTION
Adds DeclareArgs and BindArgs to ListenConfig struct:

- Those will be used when invoking CreateConsumer, which now requires both arguments;